### PR TITLE
feat: add output of agent waiting time and agent turnaround time

### DIFF
--- a/openagi/src/agents/agent_process.py
+++ b/openagi/src/agents/agent_process.py
@@ -74,7 +74,6 @@ class AgentProcess:
     def set_response(self, response):
         self.response = response
 
-
     def get_time_limit(self):
         return self.time_limit
 


### PR DESCRIPTION
1. add output of agent waiting time and agent turnaround time.  
    Current output of agent execution will contain 4 values (agent_waiting_time, agent_turnaround_time, request_waiting_times, request_turnaround_times)