### PR TITLE
fix: change the name of agent execution time to agent turnaround time

### DIFF
--- a/openagi/src/agents/base.py
+++ b/openagi/src/agents/base.py
@@ -85,7 +85,6 @@ class BaseAgent:
         while agent_process.get_status() != "done":
             thread = Thread(target=self.listen, args=(agent_process, ))
             current_time = time.time()
-
             # reinitialize agent status
             agent_process.set_created_time(current_time)
             agent_process.set_response(None)

--- a/openagi/src/agents/native_agents/math_agent/math_agent.py
+++ b/openagi/src/agents/native_agents/math_agent/math_agent.py
@@ -97,7 +97,7 @@ class MathAgent(BaseAgent):
             "result": final_result,
             "rounds": rounds,
             "agent_waiting_time": self.start_time - self.created_time,
-            "agent_execution_time": self.end_time - self.created_time,
+            "agent_turnaround_time": self.end_time - self.created_time,
             "request_waiting_times": request_waiting_times,
             "request_turnaround_times": request_turnaround_times,
         }

--- a/openagi/src/agents/native_agents/narrative_agent/narrative_agent.py
+++ b/openagi/src/agents/native_agents/narrative_agent/narrative_agent.py
@@ -83,7 +83,7 @@ class NarrativeAgent(BaseAgent):
             "result": final_result,
             "rounds": rounds,
             "agent_waiting_time": self.start_time - self.created_time,
-            "agent_execution_time": self.end_time - self.created_time,
+            "agent_turnaround_time": self.end_time - self.created_time,
             "request_waiting_times": request_waiting_times,
             "request_turnaround_times": request_turnaround_times,
         }

--- a/openagi/src/agents/native_agents/rec_agent/rec_agent.py
+++ b/openagi/src/agents/native_agents/rec_agent/rec_agent.py
@@ -83,7 +83,7 @@ class RecAgent(BaseAgent):
             "result": final_result,
             "rounds": rounds,
             "agent_waiting_time": self.start_time - self.created_time,
-            "agent_execution_time": self.end_time - self.created_time,
+            "agent_turnaround_time": self.end_time - self.created_time,
             "request_waiting_times": request_waiting_times,
             "request_turnaround_times": request_turnaround_times,
         }


### PR DESCRIPTION
1. change the name of agent execution time to agent turnaround time