### PR TITLE
feat: add tool calling for chatgpt-based math agent

### DIFF
--- a/openagi/src/agents/agent_config/MathAgent.json
+++ b/openagi/src/agents/agent_config/MathAgent.json
@@ -1,13 +1,41 @@
 {
     "name": "MathAgent",
     "description": [
-        "You are an expert who is good at solving mathematical problems. ",
-        "Given a mathematical problem, if the problem is complex, you need to break down this problem into smaller sub-problems and solve."
+        "You are an expert who is good at solving mathematical problems. "
     ],
-    "flow": [
-
+    "workflow": [
+        "use a currency converter tool to get the currency information. ",
+        "perform mathematical operations using the converted currency amount, which could involve addition, subtraction, multiplication, or division with other numeric values to solve the problem."
     ],
-    "tool_info": [
-
+    "tools": [
+        {
+            "type": "function",
+            "function": {
+                "name": "currency_converter",
+                "description": "Provides currency exchange rates convert base currency to desired currency with the given amount",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "from": {
+                            "type": "string",
+                            "description": "Base currency code, e.g., AUD, CAD, EUR, GBP..."
+                        },
+                        "to": {
+                            "type": "string", 
+                            "description": "Desired currency code, e.g., AUD, CAD, EUR, GBP..."
+                        },
+                        "amount": {
+                            "type": "string", 
+                            "default": "1.0",
+                            "description": "The amount to be converted"
+                        }
+                    },
+                    "required": [
+                        "from",
+                        "to"
+                    ]
+                }
+            }
+        }
     ]
 }

--- a/openagi/src/agents/agent_factory.py
+++ b/openagi/src/agents/agent_factory.py
@@ -12,8 +12,6 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from threading import Thread, Lock, Event
 
-# from multiprocessing import Process, Lock, Event
-
 from pympler import asizeof
 
 class AgentFactory:
@@ -104,10 +102,3 @@ class AgentFactory:
     def deactivate_agent(self, aid):
         self.current_agents.pop(aid)
         heapq.heappush(self.aid_pool, aid)
-
-    def start(self):
-        """start the factory to check inactive agent"""
-        self.thread.start()
-
-    def stop(self):
-        self.thread.join()

--- a/openagi/src/agents/agent_process.py
+++ b/openagi/src/agents/agent_process.py
@@ -14,10 +14,15 @@ from threading import Thread, Lock, Event
 
 from pympler import asizeof
 
+from ..utils.message import Message
+
 class AgentProcess:
-    def __init__(self, agent_name, prompt):
+    def __init__(self, 
+            agent_name,
+            message
+        ):
         self.agent_name = agent_name
-        self.prompt = prompt
+        self.message = message
         self.pid: int = None
         self.status = None
         self.response = None
@@ -62,12 +67,6 @@ class AgentProcess:
     def get_pid(self):
         return self.pid
 
-    def set_prompt(self, prompt):
-        self.prompt = prompt
-
-    def get_prompt(self):
-        return self.prompt
-
     def get_response(self):
         return self.response
 
@@ -96,12 +95,12 @@ class AgentProcessFactory:
 
         self.agent_process_log_mode = agent_process_log_mode
 
-    def activate_agent_process(self, agent_name, prompt):
+    def activate_agent_process(self, agent_name, message):
         if not self.terminate_signal.is_set():
             with self.current_agent_processes_lock:
                 agent_process = AgentProcess(
                     agent_name = agent_name,
-                    prompt = prompt,
+                    message = message
                 )
                 pid = heapq.heappop(self.pid_pool)
                 agent_process.set_pid(pid)
@@ -143,19 +142,6 @@ class AgentProcessFactory:
         return row_str
 
     def deactivate_agent_process(self, pid):
-        # import time
-        # while not self.terminate_signal.is_set():
-        #     with self.current_agent_processes_lock:
-        #         invalid_pids = []
-        #         items = self.current_agent_processes.items()
-        #         for pid, agent_process in items:
-        #             if agent_process.get_status() == "done":
-        #                 # agent.set_status("inactive")
-        #                 time.sleep(5)
-        #                 invalid_pids.append(pid)
-        #         for pid in invalid_pids:
-        #             self.current_agent_processes.pop(pid)
-        #             heapq.heappush(self.pid_pool, pid)
         self.current_agent_processes.pop(pid)
         heapq.heappush(self.pid_pool, pid)
 

--- a/openagi/src/agents/native_agents/math_agent/math_agent.py
+++ b/openagi/src/agents/native_agents/math_agent/math_agent.py
@@ -19,7 +19,11 @@ from ....tools.online.currency_converter import CurrencyConverterAPI
 
 from ....tools.online.wolfram_alpha import WolframAlpha
 
+from ....utils.message import Message
+
 import time
+
+import json
 
 import re
 class MathAgent(BaseAgent):
@@ -32,13 +36,11 @@ class MathAgent(BaseAgent):
         ):
         BaseAgent.__init__(self, agent_name, task_input, llm, agent_process_queue, agent_process_factory, log_mode)
         self.tool_list = {
-            # "wolfram_alpha": WolframAlpha(),
-            # "currenct_converter": CurrencyConverterAPI()
+            "wolfram_alpha": WolframAlpha(),
+            "currency_converter": CurrencyConverterAPI()
         }
-        self.tool_check_max_fail_times = 10
-        self.tool_select_max_fail_times = 10
-        self.tool_calling_max_fail_times = 10
-        self.tool_info = "".join(self.config["tool_info"])
+        self.workflow = self.config["workflow"]
+        self.tools = self.config["tools"]
 
     def load_flow(self):
         return
@@ -56,42 +58,69 @@ class MathAgent(BaseAgent):
         self.logger.log(f"{task_input}\n", level="info")
 
         rounds = 0
+
         # predefined steps
-        steps = [
-            "identify and outline the sub-problems that need to be solved as stepping stones toward the solution. ",
-            "solve each sub-problem. ",
-            "integrate the solutions to these sub-problems in the previous step to get the final solution. "
-        ]
-        for i, step in enumerate(steps):
-            prompt += f"\nIn step {i+1}, you need to {step}. Output should focus on current step and don't be verbose!"
+        # TODO replace fixed steps with dynamic steps
+        # Step 1 "use a currency converter tool to get the currency information. ",
+        # Step 2 "perform mathematical operations using the converted currency amount, which could involve addition, subtraction, multiplication, or division with other numeric values to solve the problem."
 
-            self.logger.log(f"Step {i+1}: {step}\n", level="info")
-            response, start_times, end_times, waiting_times, turnaround_times = self.get_response(prompt)
+        for i, step in enumerate(self.workflow):
+            prompt += f"\nIn step {rounds + 1}, you need to {step}. Output should focus on current step and don't be verbose!"
+            if i == 0:
+                response, start_times, end_times, waiting_times, turnaround_times = self.get_response(
+                    message = Message(
+                        prompt = prompt,
+                        tools = self.tools
+                    )
+                )
+                response_message = response.response_message
 
-            if rounds == 0:
                 self.set_start_time(start_times[0])
 
-            rounds += 1
+                tool_calls = response.tool_calls
 
-            request_waiting_times.extend(waiting_times)
-            request_turnaround_times.extend(turnaround_times)
-            prompt += f"The solution to step {i+1} is: {response}\n"
-            self.logger.log(f"The solution to step {i+1}: {response}\n", level="info")
+                if tool_calls:
 
-        prompt += f"Given the interaction history: '{prompt}', integrate solutions in all steps to give a final answer, don't be verbose!"
+                    request_waiting_times.extend(waiting_times)
+                    request_turnaround_times.extend(turnaround_times)
 
-        final_result, start_times, end_times, waiting_times, turnaround_times = self.get_response(prompt)
-        request_waiting_times.extend(waiting_times)
-        request_turnaround_times.extend(turnaround_times)
+                    function_responses = ""
+                    if tool_calls:
+                        for tool_call in tool_calls:
+                            function_name = tool_call.function.name
+                            function_to_call = self.tool_list[function_name]
+                            function_args = json.loads(tool_call.function.arguments)
+
+                            function_response = function_to_call.run(function_args)
+                            function_responses += function_response
+                            prompt += function_response
+
+                    self.logger.log(f"The solution to step {rounds+1}: {function_responses}\n", level="info")
+                
+                else:
+                    self.logger.log(f"The solution to step {rounds+1}: {response_message}\n", level="info")
+
+                rounds += 1
+
+            else:
+                response, start_times, end_times, waiting_times, turnaround_times = self.get_response(
+                    message = Message(
+                        prompt = prompt,
+                        tools = None
+                    )
+                )
+                response_message = response.response_message
+
+                if i == len(self.workflow) - 1:
+                    self.logger.log(f"Final result is: {response_message}\n", level="info")
+                    final_result = response_message
+
+                else:
+                    self.logger.log(f"The solution to step {rounds+1}: {response_message}\n", level="info")
 
         self.set_status("done")
         self.set_end_time(time=time.time())
 
-        self.logger.log(
-            f"{task_input} Final result is: {final_result}\n",
-            level="info"
-        )
-        
         return {
             "agent_name": self.agent_name,
             "result": final_result,

--- a/openagi/src/tools/online/currency_converter.py
+++ b/openagi/src/tools/online/currency_converter.py
@@ -26,12 +26,12 @@ class CurrencyConverterAPI(BaseRapidAPITool):
             self.query_string = {
                 "from": params["from"],
                 "to": params["to"],
-                "amount": params["amount"]
+                "amount": params["amount"] if "amount" in params else "1.0"
             }
         except ValueError:
             raise KeyError(
                 "The keys in params do not match the excepted keys in params for currency converter api. "
-                "Please make sure it contains two keys: 'from' and 'to' and 'amount"
+                "Please make sure it contains two keys: 'from' and 'to'"
             )
 
         # print(self.query_string)

--- a/openagi/src/utils/message.py
+++ b/openagi/src/utils/message.py
@@ -1,0 +1,18 @@
+class Message:
+    def __init__(self,
+            prompt, 
+            context = None, 
+            tools = None
+        ) -> None:
+        self.prompt = prompt
+        self.context = context
+        self.tools = tools
+
+class Response:
+    def __init__(
+            self, 
+            response_message,
+            tool_calls = None
+        ) -> None:
+        self.response_message = response_message
+        self.tool_calls = tool_calls


### PR DESCRIPTION
1. add tool calling for chatgpt-based math agent
2. refactor and wrap LLM request and LLM response, which can be found in utils.message.py. 

Message object to wrap LLM request
```python
class Message:
    def __init__(self,
            prompt, 
            context = None, 
            tools = None
        ) -> None:
        self.prompt = prompt
        self.context = context
        self.tools = tools
```
Response object to wrap LLM response 
```python
class Response:
    def __init__(
            self, 
            response_message,
            tool_calls = None
        ) -> None:
        self.response_message = response_message
        self.tool_calls = tool_calls
```